### PR TITLE
Add twister function and custom docker container

### DIFF
--- a/.functions
+++ b/.functions
@@ -128,3 +128,21 @@ function ncd() {
   cd ${NCS_WT_PATH}/$1
   cd nrf
 }
+
+# run twister command inside docker
+function twister() {
+  if [[ -z $1 ]] ; then
+    echo "Missing twister command"
+    return 1
+  fi
+
+  if [[ -z $ZEPHYR_BASE ]] ; then
+    echo "ZEPHYR_BASE is empty"
+    return 1
+  fi
+
+  prj_root=$(realpath $ZEPHYR_BASE/..)/
+  rel_cwd=${PWD#$prj_root}
+
+  docker run --rm -t -v ${prj_root}:/workdir -w /workdir/${rel_cwd} dotfiles west twister $*
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM zephyrprojectrtos/zephyr-build:v0.26.13
+
+USER root
+RUN apt-get update && apt-get install -y ruby
+
+USER user

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Shortcut to open a VS Code workspace for the current worktree.
 | mc      | menuconfig                                   |
 | greb    | grep <filename> <searchstring> in the build folder |
 | grebc   | grep in .config files in the build folder    |
+| twister | Run `west twister` inside a Zephyr docker container |
 
 #### Other aliases/functions
 
@@ -169,6 +170,12 @@ See [.shellrc](.shellrc) for which filenames it checks for. As you might notice,
     Compile yourself or download pre-compiled exe from the [GitHub repo](https://github.com/go-toast/toast).
 
     Add the exe to your PATH.
+
+### macOS dependencies
+
+* Docker
+
+    To be able execute twister tests in native_sim on macOS.
 
 ### Optional dependencies
 

--- a/install.sh
+++ b/install.sh
@@ -57,4 +57,9 @@ fi
 
 install_file west-completion.sh ~/west-completion.sh
 
+# build customized zephyr docker image used for running twister tests in native_sim
+if command -v docker &> /dev/null; then
+    docker build -t dotfiles .
+fi
+
 unset file;


### PR DESCRIPTION
This makes it possible for non-linux users to execute twister tests using the native_sim platform.

arm64 users might need to use native_sim/native/64 instead of native_sim.